### PR TITLE
Add phpunit testsuites for each recipe and add to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: php
+
+addons:
+  apt:
+    packages:
+      - hunspell
+      - libhunspell-dev
+      - hunspell-en-us
+
+env:
+  global:
+    - COMPOSER_ROOT_VERSION="4.1.x-dev"
+    - DB=MYSQL
+
+matrix:
+  include:
+    - php: 5.6
+      env: PHPUNIT_TEST=Default PDO=1
+    - php: 7.1
+      env: PHPUNIT_TEST=recipe-core
+    - php: 5.6
+      env: PHPUNIT_TEST=recipe-cms
+    - php: 7.1
+      env: PHPUNIT_TEST=cwp-recipe-core PDO=1
+    - php: 7.0
+      env: PHPUNIT_TEST=cwp-recipe-cms
+    - php: 7.2
+      env: PHPUNIT_TEST=cwp-recipe-search PDO=1
+    - php: 5.6
+      env: PHPUNIT_TEST=recipe-authoring-tools
+    - php: 7.0
+      env: PHPUNIT_TEST=recipe-blog
+    - php: 7.1
+      env: PHPUNIT_TEST=recipe-collaboration
+    - php: 7.2
+      env: PHPUNIT_TEST=recipe-content-blocks
+    - php: 5.6
+      env: PHPUNIT_TEST=recipe-form-building
+    - php: 7.0
+      env: PHPUNIT_TEST=recipe-reporting-tools
+    - php: 7.1
+      env: PHPUNIT_TEST=recipe-services
+
+before_script:
+  # Configure PHP
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini || true
+  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+  # Install dependencies
+  - composer validate
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+  # Validate cow schema
+  - composer global require silverstripe/cow ^2
+  - ~/.composer/vendor/bin/cow schema:validate
+
+script:
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit --testsuite "$PHPUNIT_TEST"; fi

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "silverstripe/recipe-plugin": "^1",
         "cwp/cwp-installer": "2.x-dev",
-        "cwp/agency-extensions": "2.x-dev",
+        "cwp/agency-extensions": "2.0.x-dev",
         "cwp/watea-theme": "2.x-dev",
         "silverstripe/controllerpolicy": "2.x-dev",
         "silverstripe/crontask": "2.x-dev",
@@ -15,8 +15,7 @@
         "silverstripe/ldap": "1.0.x-dev",
         "silverstripe/recipe-content-blocks": "1.x-dev",
         "dnadesign/silverstripe-elemental-subsites": "1.x-dev",
-        "dnadesign/silverstripe-elemental-userforms": "1.x-dev",
-        "undefinedoffset/sortablegridfield": "2.0.x-dev"
+        "dnadesign/silverstripe-elemental-userforms": "1.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+    <!-- Core SilverStripe recipes -->
+    <testsuite name="recipe-core">
+        <directory>vendor/silverstripe/framework/tests/php/</directory>
+        <directory>vendor/silverstripe/config/tests</directory>
+        <directory>vendor/silverstripe/assets/tests/php/</directory>
+        <directory>vendor/silverstripe/versioned/tests/php/</directory>
+    </testsuite>
+
+    <testsuite name="recipe-cms">
+        <directory>vendor/silverstripe/cms/tests/</directory>
+        <directory>vendor/silverstripe/admin/tests/php/</directory>
+        <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
+        <directory>vendor/silverstripe/asset-admin/tests/php/</directory>
+        <directory>vendor/silverstripe/graphql/tests/</directory>
+        <directory>vendor/silverstripe/siteconfig/tests/php/</directory>
+        <directory>vendor/silverstripe/reports/tests/</directory>
+    </testsuite>
+
+    <!-- Optional CWP modules that aren't in recipes -->
+    <testsuite name="Default">
+        <directory>mysite/tests</directory>
+        <directory>vendor/silverstripe/subsites/tests</directory>
+        <directory>vendor/silverstripe/registry/tests</directory>
+        <directory>vendor/tractorcow/silverstripe-fluent/tests</directory>
+    </testsuite>
+
+    <!-- Core CWP recipes -->
+    <testsuite name="cwp-recipe-core">
+        <directory>vendor/cwp/cwp-core/tests</directory>
+        <directory>vendor/silverstripe/auditor/tests</directory>
+        <directory>vendor/silverstripe/environmentcheck/tests</directory>
+        <directory>vendor/silverstripe/hybridsessions/tests</directory>
+        <directory>vendor/silverstripe/mimevalidator/tests</directory>
+    </testsuite>
+
+    <testsuite name="cwp-recipe-cms">
+        <directory>vendor/cwp/cwp-core/tests</directory>
+        <directory>vendor/cwp/cwp/tests</directory>
+        <directory>vendor/cwp/cwp-pdfexport/tests</directory>
+        <directory>vendor/silverstripe/html5/tests</directory>
+        <directory>vendor/symbiote/silverstripe-gridfieldextensions/tests</directory>
+    </testsuite>
+
+    <testsuite name="cwp-recipe-search">
+        <directory>vendor/cwp/cwp</directory>
+        <directory>vendor/cwp/cwp-search/tests</directory>
+        <directory>vendor/silverstripe/fulltextsearch/tests</directory>
+        <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+    </testsuite>
+
+    <!-- Optional SilverStripe recipes -->
+    <testsuite name="recipe-authoring-tools">
+        <directory>vendor/silverstripe/documentconverter/tests</directory>
+        <directory>vendor/silverstripe/iframe/tests</directory>
+        <directory>vendor/silverstripe/spellcheck/tests</directory>
+        <directory>vendor/silverstripe/tagfield/tests</directory>
+        <directory>vendor/silverstripe/taxonomy/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-blog">
+        <directory>vendor/silverstripe/blog/tests</directory>
+        <directory>vendor/silverstripe/widgets/tests</directory>
+        <directory>vendor/silverstripe/content-widget/tests</directory>
+        <directory>vendor/silverstripe/spamprotection/tests</directory>
+        <directory>vendor/silverstripe/akismet/tests</directory>
+        <directory>vendor/silverstripe/comments/tests</directory>
+        <directory>vendor/silverstripe/comment-notifications/tests</directory>
+        <directory>vendor/colymba/gridfield-bulk-editing-tools/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-collaboration">
+        <directory>vendor/silverstripe/contentreview/tests</directory>
+        <directory>vendor/silverstripe/sharedraftcontent/tests</directory>
+        <directory>vendor/symbiote/silverstripe-advancedworkflow/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-content-blocks">
+        <directory>vendor/dnadesign/silverstripe-elemental/tests</directory>
+        <directory>vendor/silverstripe/elemental-blocks/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-form-building">
+        <directory>vendor/silverstripe/segment-field/tests</directory>
+        <directory>vendor/silverstripe/userforms/tests</directory>
+        <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-reporting-tools">
+        <directory>vendor/silverstripe/externallinks/tests</directory>
+        <directory>vendor/silverstripe/reports/tests</directory>
+        <directory>vendor/silverstripe/securityreport/tests</directory>
+        <directory>vendor/silverstripe/sitewidecontent-report/tests</directory>
+    </testsuite>
+
+    <testsuite name="recipe-services">
+        <directory>vendor/silverstripe/restfulserver/tests</directory>
+        <directory>vendor/silverstripe/versionfeed/tests</directory>
+    </testsuite>
+</phpunit>


### PR DESCRIPTION
This adds a Travis build for each recipe in the CWP "kitchen sink".

Note: the recipe-core testsuite times out taking far too long to run. We may need to split it up into shorter test suites.