### PR TITLE
Separate framework test suites from core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: PHPUNIT_TEST=Default PDO=1
     - php: 7.1
       env: PHPUNIT_TEST=recipe-core
+    - php: 7.2
+      env: PHPUNIT_TEST=framework-orm
+    - php: 7.2
+      env: PHPUNIT_TEST=framework-core
     - php: 5.6
       env: PHPUNIT_TEST=recipe-cms
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "dnadesign/silverstripe-elemental-userforms": "1.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "mikey179/vfsStream": "^1.6"
     },
     "extra": {
         "project-files": [],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <!-- Core SilverStripe recipes -->
+    <!-- Core SilverStripe modules (except framework) -->
     <testsuite name="recipe-core">
-        <directory>vendor/silverstripe/framework/tests/php/</directory>
         <directory>vendor/silverstripe/config/tests</directory>
         <directory>vendor/silverstripe/assets/tests/php/</directory>
         <directory>vendor/silverstripe/versioned/tests/php/</directory>
+    </testsuite>
+
+    <!-- Framework tests are split up to run in parallel -->
+    <testsuite name="framework-orm">
+        <directory>vendor/silverstripe/framework/tests/php/ORM</directory>
+        <directory>vendor/silverstripe/framework/tests/php/Security</directory>
+    </testsuite>
+    <testsuite name="framework-core">
+        <directory>vendor/silverstripe/framework/tests/php/Control</directory>
+        <directory>vendor/silverstripe/framework/tests/php/Core</directory>
+        <directory>vendor/silverstripe/framework/tests/php/Dev</directory>
+        <directory>vendor/silverstripe/framework/tests/php/Forms</directory>
+        <directory>vendor/silverstripe/framework/tests/php/Logging</directory>
+        <directory>vendor/silverstripe/framework/tests/php/View</directory>
+        <directory>vendor/silverstripe/framework/tests/php/i18n</directory>
     </testsuite>
 
     <testsuite name="recipe-cms">


### PR DESCRIPTION
Adds a required dev dependency for the silverstripe/config tests to run and splits up the framework tests into manageable chunks.