### PR TITLE
NEW Add recipe-testing dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "phpunit/phpunit": "^5.7",
         "mikey179/vfsStream": "^1.6",
         "silverstripe/frameworktest": "dev-master",
-        "silverstripe/graphql-devtools": "1.x-dev"
+        "silverstripe/graphql-devtools": "1.x-dev",
+        "silverstripe/recipe-testing": "1.x-dev"
     },
     "extra": {
         "project-files": [],


### PR DESCRIPTION
This PR adds the recipe-testing as a dev dependency. Amongst others, this includes behat-extension.