### PR TITLE
Add cow config for changelog holder, path, and include-other-changes

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -1,5 +1,8 @@
 {
   "github-slug": "silverstripe/cwp-recipe-kitchen-sink",
+  "changelog-holder": "cwp/cwp",
+  "changelog-path": "docs/en/05_Releases_and_changelogs/cwp_{version}.md",
+  "changelog-include-other-changes": true,
   "child-stability-inherit": [
     "cwp/cwp-installer",
     "silverstripe/recipe-content-blocks"


### PR DESCRIPTION
This will ensure that other changes are always included in CWP changelogs without needing to remember to add the CLI argument.

Issue: https://github.com/silverstripe/cow/issues/122