### PR TITLE
Enable watea theme by default in kitchen sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+themes/
+silverstripe-cache/

--- a/app/_config/theme.yml
+++ b/app/_config/theme.yml
@@ -1,0 +1,9 @@
+---
+Name: cwptheme
+---
+SilverStripe\View\SSViewer:
+  themes:
+    - '$public'
+    - 'watea'
+    - 'starter'
+    - '$default'


### PR DESCRIPTION
Fixes #28 

By having this file in the project already, it shouldn't be added automatically by the cwp-installer's project-files and will be skipped in favour of the existing file.
