### PR TITLE
Add changelog template

### DIFF
--- a/.changelog.md.twig
+++ b/.changelog.md.twig
@@ -1,0 +1,32 @@
+# {{ version }}
+
+## Overview
+
+This release includes CMS and Framework version X.X.X.
+
+- [Framework X.X.X](#)
+
+Upgrading to Recipe {{ version }} is optional, but is recommended for all CWP sites.
+
+This upgrade can be carried out by any development team familiar with SilverStripe CMS, but if you would like SilverStripe's assistance, please let us know.
+
+## Upgrading instructions
+
+In order to update an existing site to use the new basic recipe the following changes to your composer.json can be made:
+
+```
+...
+```
+
+(...other upgrade notes here)
+
+## Known issues
+
+...
+
+## Security considerations
+
+...
+
+{{ logs }}
+

--- a/.cow.json
+++ b/.cow.json
@@ -1,5 +1,9 @@
 {
   "github-slug": "silverstripe/cwp-recipe-kitchen-sink",
+  "changelog-holder": "cwp/cwp",
+  "changelog-path": "docs/en/05_Releases_and_changelogs/cwp_{version}.md",
+  "changelog-template": ".changelog.md.twig",
+  "changelog-include-other-changes": true,
   "child-stability-inherit": [
     "cwp/cwp-installer",
     "silverstripe/recipe-content-blocks"


### PR DESCRIPTION
This template is used by Cow to populate fresh changelogs. I've written it to roughly match the format we've been following in recent releases.