### PR TITLE
DOCS new headings for change log template

### DIFF
--- a/.changelog.md.twig
+++ b/.changelog.md.twig
@@ -6,27 +6,39 @@ This release includes CMS and Framework version X.X.X.
 
 - [Framework X.X.X](#)
 
-Upgrading to Recipe {{ version }} is optional, but is recommended for all CWP sites.
+Upgrading to Recipe {{ version }} is recommended for all CWP sites. This upgrade can be carried out by any development team familiar with SiliverStripe CMS. However, if you would like SilverStripe's assistance, you can request support via the [Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 
-This upgrade can be carried out by any development team familiar with SilverStripe CMS, but if you would like SilverStripe's assistance, please let us know.
+## New Features
 
-## Upgrading instructions
+The [release announcement](#) includes the note worthy features, but be sure to review the change log for full detail.
 
-In order to update an existing site to use the new basic recipe the following changes to your composer.json can be made:
+{{ other upgrade notes here }}
+
+## Known Issues
+
+* {{ [Known issue](GitHub link) }}
+
+### Expected test failures
+
+The following PHPUnit test failures are expected and do not represent functional issues in CWP:
+
+* {{ [test failure] }}
+
+## Security Considerations
+
+This release includes {{ several }} security fixes. Please see the release announcements for more detailed descriptions of each[ but note that the following issues have modified CVSS Environmental scores which take built-in protections from the CWP platform into account]. We highly encourage upgrading your CWP projects to include these security patches nonetheless.
+
+* {{ CVE issue with modified CVSS Environmental score }}, {{ new CVSS score }}
+
+## Upgrading Instructions
+
+In order to update an existing site to use the new CWP recipe the following changes to your composer.json can be made:
 
 ```
 ...
 ```
 
-(...other upgrade notes here)
-
-## Known issues
-
-...
-
-## Security considerations
 
 ...
 
 {{ logs }}
-

--- a/.changelog.md.twig
+++ b/.changelog.md.twig
@@ -8,29 +8,35 @@ This release includes CMS and Framework version X.X.X.
 
 Upgrading to Recipe {{ version }} is recommended for all CWP sites. This upgrade can be carried out by any development team familiar with SiliverStripe CMS. However, if you would like SilverStripe's assistance, you can request support via the [Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 
-## New Features
+## New features
 
 The [release announcement](#) includes the note worthy features, but be sure to review the change log for full detail.
 
-{{ other upgrade notes here }}
+{# other upgrade notes here #}
 
-## Known Issues
+## Known issues
 
-* {{ [Known issue](GitHub link) }}
+{#
+* [Known issue](GitHub link)
+#}
 
 ### Expected test failures
 
 The following PHPUnit test failures are expected and do not represent functional issues in CWP:
 
-* {{ [test failure] }}
+{# 
+* List test failures here
+#}
 
-## Security Considerations
+## Security considerations
 
-This release includes {{ several }} security fixes. Please see the release announcements for more detailed descriptions of each[ but note that the following issues have modified CVSS Environmental scores which take built-in protections from the CWP platform into account]. We highly encourage upgrading your CWP projects to include these security patches nonetheless.
+This release includes {# [several] #} security fixes. Please see the release announcements for more detailed descriptions of each[ but note that the following issues have modified CVSS Environmental scores which take built-in protections from the CWP platform into account]. We highly encourage upgrading your CWP projects to include these security patches nonetheless.
 
-* {{ CVE issue with modified CVSS Environmental score }}, {{ new CVSS score }}
+{# 
+* List CVE issue with modified CVSS Environmental score here
+#}
 
-## Upgrading Instructions
+## Upgrading instructions
 
 In order to update an existing site to use the new CWP recipe the following changes to your composer.json can be made:
 


### PR DESCRIPTION
Adding additional information to the change log template to better match the recent 2.3 release and the suggested changes in https://github.com/silverstripe/cwp/issues/188