### PR TITLE
Add inline requirements for MFA modules in Travis builds for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,19 @@ matrix:
       env: PHPUNIT_TEST=recipe-services
     - php: 7.1
       env: PHPUNIT_TEST=optional-authenticators
+    - php: 7.1
+      env: PHPUNIT_TEST=mfa
 
 before_script:
   # Configure PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
-  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   # Install dependencies
   - composer validate
+  # CWP 2.2/2.3 only: inline require MFA dependencies since they require PHP 7.1
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.1" ]]; then composer require --no-update silverstripe/mfa:4.0.x-dev silverstripe/login-forms:4.0.x-dev silverstripe/security-extensions:4.0.x-dev silverstripe/totp-authenticator:4.0.x-dev silverstripe/webauthn-authenticator:4.0.x-dev; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
   # Validate cow schema

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "silverstripe/ckan-registry": "1.0.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "silverstripe/recipe-testing": "^1",
         "mikey179/vfsstream": "^1.6"
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -132,4 +132,16 @@
         <directory>vendor/silverstripe/ldap/tests</directory>
         <directory>vendor/silverstripe/realme/tests</directory>
     </testsuite>
+
+    <!--
+        Note: in CWP 2.2 and 2.3 this is not included in the composer.json requirements since it requires
+        PHP 7.1. It will be included by default in CWP 2.4
+     -->
+    <testsuite name="mfa">
+        <directory>vendor/silverstripe/mfa/tests</directory>
+        <directory>vendor/silverstripe/login-forms/tests</directory>
+        <directory>vendor/silverstripe/security-extensions/tests</directory>
+        <directory>vendor/silverstripe/totp-authenticator/tests</directory>
+        <directory>vendor/silverstripe/webauthn-authenticator/tests</directory>
+    </testsuite>
 </phpunit>


### PR DESCRIPTION
This adds the MFA dependencies for any builds running PHP 7.1. In CWP 2.4 this will be part of composer.json, since it will require PHP 7.1 as a minimum.

Fixes https://github.com/silverstripe/cwp-recipe-kitchen-sink/issues/33

I'll adjust any test failures, reference this PR, and re-run the failures until green then self merge it.