### PR TITLE
Enable color and font pickers by default

### DIFF
--- a/app/_config/agencyextensions.yml
+++ b/app/_config/agencyextensions.yml
@@ -1,0 +1,5 @@
+---
+Name: mysiteagencyextensions
+---
+SilverStripe\SiteConfig\SiteConfig:
+  enable_theme_color_picker: true


### PR DESCRIPTION
This is a kitchen sink, so optional stuff should be enabled, right?