### PR TITLE
DOC Adjust changelog template for RC releases

### DIFF
--- a/.changelog.md.twig
+++ b/.changelog.md.twig
@@ -2,9 +2,15 @@
 
 ## Overview
 
-This release includes CMS and Framework version X.X.X.
+This release includes [CMS and Framework version X.X.X](#).
 
-- [Framework X.X.X](#)
+{% if version.stability == 'rc' %}
+
+## Release Candidate
+
+This version of CWP is a **release candidate** for an upcoming stable version, and should not be applied to production websites. We encourage developers to test this version in development / testing environments and report any issues they encounter via GitHub.
+
+{% elseif version.stable %}
 
 Upgrading to Recipe {{ version }} is recommended for all CWP sites. This upgrade can be carried out by any development team familiar with SilverStripe. However, if you would like SilverStripe's assistance, you can request support via the [Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 
@@ -46,5 +52,7 @@ In order to update an existing site to use the new CWP recipe the following chan
 
 
 ...
+
+{% endif %}
 
 {{ logs }}


### PR DESCRIPTION
For release candidates, we don't need to provide a full set of information in the changelog, so this currently gets removed by hand after generation.

Now that [we can access the full `Version` object](https://github.com/silverstripe/cow/pull/157), we can provide a special message in release candidates, and output the existing sections only in stable releases.