### PR TITLE
Increase travis memory to 3G

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
   # Configure PHP
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true
-  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'memory_limit = 3G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   # Install dependencies
   - composer validate

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -69,6 +69,16 @@
         <directory>vendor/cwp/cwp-search/tests</directory>
         <directory>vendor/silverstripe/fulltextsearch/tests</directory>
         <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+        <!--
+            These tests are excluded only on the 2.2 branch because they trigger a scenario where a
+            php shutdown function is being called from Monolog after all the unit tests pass, which in turn
+            calls an ORM query, after the database has been deleted by phpunit/SapphireTest.  Because
+            the database is no longer there, this triggers a php error which causes the travis build to fail
+            This issue does not occur in 2.3 or beyond, so these tests should not be excluded there
+            Also, this issue does not happen if you run the same unit-tests outside the context of the kitchen sink
+        -->
+        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/QueuedJobsTest.php</exclude>
+        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/ScheduledExecutionTest.php</exclude>
     </testsuite>
 
     <!-- Optional SilverStripe recipes -->
@@ -111,6 +121,16 @@
         <directory>vendor/silverstripe/segment-field/tests</directory>
         <directory>vendor/silverstripe/userforms/tests</directory>
         <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+        <!--
+            These tests are excluded only on the 2.2 branch because they trigger a scenario where a
+            php shutdown function is being called from Monolog after all the unit tests pass, which in turn
+            calls an ORM query, after the database has been deleted by phpunit/SapphireTest.  Because
+            the database is no longer there, this triggers a php error which causes the travis build to fail
+            This issue does not occur in 2.3 or beyond, so these tests should not be excluded there
+            Also, this issue does not happen if you run the same unit-tests outside the context of the kitchen sink
+        -->
+        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/QueuedJobsTest.php</exclude>
+        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/ScheduledExecutionTest.php</exclude>
     </testsuite>
 
     <testsuite name="recipe-reporting-tools">


### PR DESCRIPTION
a) Fixes travis tests that were running out of memory
b) Excludes queued jobs tests that were only failing on the 2.2 branch of kitchen-sink.  They pass fine in 2.3 and if you run the tests on the queuedjobs module by itself

Will merge this up to 2.3 and then revert the unit test exclusions so they're still included in kitchen-sink 2.3 and beyond.

Will keep the 3G memory in 2.3 and beyond because there's some tests in 2.3 that are running out of memory