### PR TITLE
Increase travis memory to 3G and re-include queuedjobs tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -69,16 +69,6 @@
         <directory>vendor/cwp/cwp-search/tests</directory>
         <directory>vendor/silverstripe/fulltextsearch/tests</directory>
         <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
-        <!--
-            These tests are excluded only on the 2.2 branch because they trigger a scenario where a
-            php shutdown function is being called from Monolog after all the unit tests pass, which in turn
-            calls an ORM query, after the database has been deleted by phpunit/SapphireTest.  Because
-            the database is no longer there, this triggers a php error which causes the travis build to fail
-            This issue does not occur in 2.3 or beyond, so these tests should not be excluded there
-            Also, this issue does not happen if you run the same unit-tests outside the context of the kitchen sink
-        -->
-        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/QueuedJobsTest.php</exclude>
-        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/ScheduledExecutionTest.php</exclude>
     </testsuite>
 
     <!-- Optional SilverStripe recipes -->
@@ -121,16 +111,6 @@
         <directory>vendor/silverstripe/segment-field/tests</directory>
         <directory>vendor/silverstripe/userforms/tests</directory>
         <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
-        <!--
-            These tests are excluded only on the 2.2 branch because they trigger a scenario where a
-            php shutdown function is being called from Monolog after all the unit tests pass, which in turn
-            calls an ORM query, after the database has been deleted by phpunit/SapphireTest.  Because
-            the database is no longer there, this triggers a php error which causes the travis build to fail
-            This issue does not occur in 2.3 or beyond, so these tests should not be excluded there
-            Also, this issue does not happen if you run the same unit-tests outside the context of the kitchen sink
-        -->
-        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/QueuedJobsTest.php</exclude>
-        <exclude>vendor/symbiote/silverstripe-queuedjobs/tests/ScheduledExecutionTest.php</exclude>
     </testsuite>
 
     <testsuite name="recipe-reporting-tools">


### PR DESCRIPTION
Follow on from https://github.com/silverstripe/cwp-recipe-kitchen-sink/pull/52 which:
a) increased travis memory to 3G
b) excluded some queuedjob tests from running which were only broken on 2.2 (not 2.3)

This PR:
a) includes a merge up from 2.2 to 2.3 so that travis memory is now 3G
b) re-includes the queued jobs tests since they do pass on 2.3