### PR TITLE
Specify php 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "homepage": "https://www.cwp.govt.nz",
     "license": "BSD-3-Clause",
     "require": {
+        "php": ">=7.1",
         "silverstripe/recipe-plugin": "^1",
         "cwp/cwp-installer": "2.5.x-dev",
         "cwp/agency-extensions": "2.3.x-dev",


### PR DESCRIPTION
Specify php 7.1 as the required version

This should prompt cow to use php 7.1 instead of php 7.3 so that the realme module (php <=7.1) can be installed