### PR TITLE
DOCS new branding in cwp change log template

### DIFF
--- a/.changelog.md.twig
+++ b/.changelog.md.twig
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This release includes [CMS and Framework version X.X.X](#).
+This release includes [Silverstripe CMS version X.X.X](#).
 
 {% if version.stability == 'rc' %}
 
@@ -12,7 +12,7 @@ This version of CWP is a **release candidate** for an upcoming stable version, a
 
 {% elseif version.stable %}
 
-Upgrading to Recipe {{ version }} is recommended for all CWP sites. This upgrade can be carried out by any development team familiar with SilverStripe. However, if you would like SilverStripe's assistance, you can request support via the [Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
+Upgrading to Recipe {{ version }} is recommended for all CWP sites. This upgrade can be carried out by any development team familiar with the Silverstripe CMS. However, if you would like Silverstripe and the CWP team's assistance, you can request support via the [Service Desk](https://www.cwp.govt.nz/service-desk/new-request/).
 
 ## New features
 


### PR DESCRIPTION
One sentence really needed a re-work, so I've also updated 'Silverstripe' to match recent branding changes. We'd be doing the same in future release announcements too.