### PR TITLE
Update for 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,24 +7,24 @@
     "require": {
         "php": ">=7.1",
         "silverstripe/recipe-plugin": "^1",
-        "cwp/cwp-installer": "2.x-dev",
-        "cwp/agency-extensions": "2.x-dev",
-        "cwp/watea-theme": "3.x-dev",
-        "silverstripe/controllerpolicy": "2.x-dev",
-        "silverstripe/crontask": "2.x-dev",
-        "silverstripe/gridfieldqueuedexport": "2.x-dev",
-        "silverstripe/ldap": "1.x-dev",
-        "silverstripe/recipe-content-blocks": "2.x-dev",
-        "dnadesign/silverstripe-elemental-userforms": "3.x-dev",
-        "silverstripe/textextraction": "3.x-dev",
-        "silverstripe/realme": "4.x-dev",
-        "silverstripe/ckan-registry": "1.x-dev",
-        "silverstripe/mfa": "4.x-dev",
-        "silverstripe/totp-authenticator": "4.x-dev",
-        "silverstripe/webauthn-authenticator": "4.x-dev",
-        "silverstripe/security-extensions": "4.x-dev",
-        "silverstripe/login-forms": "4.x-dev",
-        "symbiote/silverstripe-multivaluefield": "5.x-dev"
+        "cwp/cwp-installer": "2.6.x-dev",
+        "cwp/agency-extensions": "2.4.x-dev",
+        "cwp/watea-theme": "3.0.x-dev",
+        "silverstripe/controllerpolicy": "2.1.x-dev",
+        "silverstripe/crontask": "2.1.x-dev",
+        "silverstripe/gridfieldqueuedexport": "2.3.x-dev",
+        "silverstripe/ldap": "1.1.x-dev",
+        "silverstripe/recipe-content-blocks": "2.6.x-dev",
+        "dnadesign/silverstripe-elemental-userforms": "3.0.x-dev",
+        "silverstripe/textextraction": "3.1.x-dev",
+        "silverstripe/realme": "4.0.x-dev",
+        "silverstripe/ckan-registry": "1.1.x-dev",
+        "silverstripe/mfa": "4.1.x-dev",
+        "silverstripe/totp-authenticator": "4.0.x-dev",
+        "silverstripe/webauthn-authenticator": "4.0.x-dev",
+        "silverstripe/security-extensions": "4.0.x-dev",
+        "silverstripe/login-forms": "4.2.x-dev",
+        "symbiote/silverstripe-multivaluefield": "5.0.x-dev"
     },
     "require-dev": {
         "silverstripe/frameworktest": "dev-master",
@@ -32,10 +32,6 @@
         "silverstripe/recipe-testing": "^1",
         "mikey179/vfsstream": "^1.6",
         "sminnee/phpunit-mock-objects": "^3.4.5"
-    },
-    "suggest": {
-        "silverstripe/mfa": "Add MFA authentication. Only available in PHP ^7.1.",
-        "silverstripe/totp-authenticator": "Add TOTP for the silverstripe/mfa module. Only available in PHP ^7.1."
     },
     "extra": {
         "project-files": []


### PR DESCRIPTION
.travis.yml had no required changes

```
before_script:
  # Configure PHP
  - phpenv rehash
  - phpenv config-rm xdebug.ini || true
  - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

  - composer validate
  # Install dependencies
  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile

  # Validate cow schema
  - composer global require silverstripe/cow ^2
  - $HOME/.composer/vendor/bin/cow schema:validate

script:
  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit --testsuite "$PHPUNIT_TEST" --exclude-group exclude-from-travis; fi
```