### PR TITLE
FIX frameworktest module is now constrained to the appropriate SilverStripe 4.x release line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-mcrypt": "*"
     },
     "require-dev": {
-        "silverstripe/frameworktest": "dev-master",
+        "silverstripe/frameworktest": "4.x-dev",
         "silverstripe/graphql-devtools": "1.x-dev",
         "silverstripe/recipe-testing": "^1",
         "mikey179/vfsstream": "^1.6"


### PR DESCRIPTION
dev-master is now for SilverStripe 5.x, this PR fixes the incompatibility with that particular module's constraint. It appears that the build matrix is very very broken, this PR doesn't intend to resolve that issue.