### PR TITLE
Target framework 4.x-dev on the sink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-mcrypt": "*"
     },
     "require-dev": {
-        "silverstripe/frameworktest": "dev-master",
+        "silverstripe/frameworktest": "4.x-dev",
         "silverstripe/graphql-devtools": "1.x-dev",
         "silverstripe/recipe-testing": "^1",
         "mikey179/vfsstream": "^1.6"


### PR DESCRIPTION
Need to tweak the version of framework test we install because of https://github.com/silverstripe/silverstripe-frameworktest/pull/70