### PR TITLE
Remove mcrypt from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "silverstripe/webauthn-authenticator": "4.0.x-dev",
         "silverstripe/security-extensions": "4.0.x-dev",
         "silverstripe/login-forms": "4.2.x-dev",
-        "symbiote/silverstripe-multivaluefield": "5.0.x-dev",
-        "ext-mcrypt": "*"
+        "symbiote/silverstripe-multivaluefield": "5.0.x-dev"
     },
     "require-dev": {
         "silverstripe/frameworktest": "4.x-dev",


### PR DESCRIPTION
Mcrypt no longer exists in PHP7.4